### PR TITLE
Add analytics module with Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@
 - `main.js`: Semua logic aplikasi, penyimpanan lokal, export/import, dsb
 
 > Setelah pemisahan file, mudah di-maintain dan scalable!
+
+## Testing
+
+Install dependencies sekali dengan `npm install` lalu jalankan `npm test` untuk
+mengeksekusi suite Jest.

--- a/index.html
+++ b/index.html
@@ -168,6 +168,7 @@
   </div>
 
   <!-- Link to External JS -->
+  <script src="src/analytics.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -37,31 +37,16 @@ function forceUppercaseInput() {
   });
 }
 
-// Function to calculate analytics
+// Function to update analytics UI using computeAnalytics from analytics module
 function calculateAnalytics() {
-  const totalTrades = trades.length;
-  const winTrades = trades.filter(trade => trade.wl === "Win").length;
-  const lossTrades = totalTrades - winTrades;
-  
-  // Calculate winrate
-  const winrate = totalTrades > 0 ? (winTrades / totalTrades * 100) : 0;
-  
-  // Calculate profit factor
-  let totalWinRR = 0;
-  let totalLossRR = 0;
-  
-  trades.forEach(trade => {
-    if (trade.wl === "Win" && trade.rr) {
-      const rrParts = trade.rr.split(':');
-      if (rrParts.length === 2) {
-        totalWinRR += parseFloat(rrParts[0]);
-      }
-    } else if (trade.wl === "Loss") {
-      totalLossRR += 1;
-    }
-  });
-  
-  const profitFactor = totalLossRR > 0 ? (totalWinRR / totalLossRR) : totalWinRR > 0 ? Infinity : 0;
+  // computeAnalytics is provided by src/analytics.js
+  const {
+    totalTrades,
+    winTrades,
+    lossTrades,
+    winrate,
+    profitFactor
+  } = computeAnalytics(trades);
   
   // Update analytics UI
   totalTradesEl.textContent = totalTrades;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jurnal_trading",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
+  }
+}

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,34 @@
+function computeAnalytics(trades) {
+  const totalTrades = trades.length;
+  const winTrades = trades.filter(trade => trade.wl === "Win").length;
+  const lossTrades = totalTrades - winTrades;
+
+  const winrate = totalTrades > 0 ? (winTrades / totalTrades * 100) : 0;
+
+  let totalWinRR = 0;
+  let totalLossRR = 0;
+
+  trades.forEach(trade => {
+    if (trade.wl === "Win" && trade.rr) {
+      const rrParts = trade.rr.split(':');
+      if (rrParts.length === 2) {
+        totalWinRR += parseFloat(rrParts[0]);
+      }
+    } else if (trade.wl === "Loss") {
+      totalLossRR += 1;
+    }
+  });
+
+  const profitFactor = totalLossRR > 0 ? (totalWinRR / totalLossRR)
+    : totalWinRR > 0 ? Infinity : 0;
+
+  return { totalTrades, winTrades, lossTrades, winrate, profitFactor };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { computeAnalytics };
+}
+
+if (typeof window !== 'undefined') {
+  window.computeAnalytics = computeAnalytics;
+}

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,0 +1,34 @@
+const { computeAnalytics } = require('../src/analytics');
+
+describe('computeAnalytics', () => {
+  test('calculates metrics for mixed trades', () => {
+    const trades = [
+      { wl: 'Win', rr: '2:1' },
+      { wl: 'Loss' },
+      { wl: 'Win', rr: '1.5:1' }
+    ];
+
+    const result = computeAnalytics(trades);
+
+    expect(result.totalTrades).toBe(3);
+    expect(result.winTrades).toBe(2);
+    expect(result.lossTrades).toBe(1);
+    expect(result.winrate).toBeCloseTo(66.6, 1);
+    expect(result.profitFactor).toBeCloseTo(3.5, 1);
+  });
+
+  test('calculates metrics for all losses', () => {
+    const trades = [
+      { wl: 'Loss' },
+      { wl: 'Loss' }
+    ];
+
+    const result = computeAnalytics(trades);
+
+    expect(result.totalTrades).toBe(2);
+    expect(result.winTrades).toBe(0);
+    expect(result.lossTrades).toBe(2);
+    expect(result.winrate).toBe(0);
+    expect(result.profitFactor).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest config in `package.json`
- extract analytics logic to `src/analytics.js`
- update `main.js` to use the analytics module
- load the module in `index.html`
- add example tests for analytics
- document how to run tests in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850de1a773483218246edb81836a42c